### PR TITLE
Migrate from asdf-vm to mise

### DIFF
--- a/.asdfrc
+++ b/.asdfrc
@@ -1,1 +1,0 @@
-legacy_version_file = yes

--- a/.zsh/config/completion.zsh
+++ b/.zsh/config/completion.zsh
@@ -1,19 +1,13 @@
-# asdf-vm
-if [[ -e ~/.asdf ]]; then
-    # shellcheck disable=SC2206
-    fpath=(~/.asdf/completions "${fpath[@]}")
-
-    # compinit with zi turbo mode
-    # https://wiki.zshell.dev/ja/docs/guides/commands
-    zicompinit
-fi
+# compinit with zi turbo mode
+# https://wiki.zshell.dev/ja/docs/guides/commands
+zicompinit
 
 # aws
 if type aws > /dev/null 2>&1; then
     aws () {
         unset -f aws
         # lazy load
-        source "$(asdf which aws_zsh_completer.sh)"
+        source "$(mise which aws_zsh_completer.sh)"
         aws "$@"
     }
 fi

--- a/.zsh/config/plugin.zsh
+++ b/.zsh/config/plugin.zsh
@@ -69,15 +69,18 @@ typeset -g POWERLEVEL9K_VCS_STAGED_ICON=$'\uF055 ' # 
 
 # mise custom segments
 function prompt_mise_node() {
-    local v=$(mise current node 2>/dev/null)
+    local v
+    v=$(mise current node 2>/dev/null)
     [[ -n $v ]] && p10k segment -t "$v"
 }
 function prompt_mise_ruby() {
-    local v=$(mise current ruby 2>/dev/null)
+    local v
+    v=$(mise current ruby 2>/dev/null)
     [[ -n $v ]] && p10k segment -t "$v"
 }
 function prompt_mise_python() {
-    local v=$(mise current python 2>/dev/null)
+    local v
+    v=$(mise current python 2>/dev/null)
     [[ -n $v ]] && p10k segment -t "$v"
 }
 

--- a/.zsh/config/plugin.zsh
+++ b/.zsh/config/plugin.zsh
@@ -30,7 +30,7 @@ zi depth=1 light-mode for \
 
 # powerlevel10k
 typeset -g POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir dir_writable)
-typeset -g POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(vcs newline asdf aws)
+typeset -g POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(vcs newline mise_node mise_ruby mise_python aws)
 typeset -g POWERLEVEL9K_MULTILINE_FIRST_PROMPT_PREFIX=''
 typeset -g POWERLEVEL9K_MULTILINE_LAST_PROMPT_PREFIX=' %F{cyan}$ '
 typeset -g POWERLEVEL9K_PROMPT_ON_NEWLINE=true
@@ -67,16 +67,31 @@ typeset -g POWERLEVEL9K_VCS_UNTRACKED_ICON=$'\uF059 ' # 
 typeset -g POWERLEVEL9K_VCS_UNSTAGED_ICON=$'\uF06A ' # 
 typeset -g POWERLEVEL9K_VCS_STAGED_ICON=$'\uF055 ' # 
 
-typeset -g POWERLEVEL9K_PYENV_FOREGROUND='deepskyblue4'
-typeset -g POWERLEVEL9K_PYENV_BACKGROUND='none'
-typeset -g POWERLEVEL9K_PYTHON_ICON=$'\uE606' # 
+# mise custom segments
+function prompt_mise_node() {
+    local v=$(mise current node 2>/dev/null)
+    [[ -n $v ]] && p10k segment -t "$v"
+}
+function prompt_mise_ruby() {
+    local v=$(mise current ruby 2>/dev/null)
+    [[ -n $v ]] && p10k segment -t "$v"
+}
+function prompt_mise_python() {
+    local v=$(mise current python 2>/dev/null)
+    [[ -n $v ]] && p10k segment -t "$v"
+}
 
-typeset -g POWERLEVEL9K_RBENV_FOREGROUND='red'
-typeset -g POWERLEVEL9K_RBENV_BACKGROUND='none'
+typeset -g POWERLEVEL9K_MISE_NODE_FOREGROUND='green'
+typeset -g POWERLEVEL9K_MISE_NODE_BACKGROUND='none'
+typeset -g POWERLEVEL9K_MISE_NODE_VISUAL_IDENTIFIER_EXPANSION=$'⬢'
 
-typeset -g POWERLEVEL9K_ASDF_FOREGROUND='purple'
-typeset -g POWERLEVEL9K_ASDF_BACKGROUND='none'
+typeset -g POWERLEVEL9K_MISE_RUBY_FOREGROUND='red'
+typeset -g POWERLEVEL9K_MISE_RUBY_BACKGROUND='none'
+typeset -g POWERLEVEL9K_MISE_RUBY_VISUAL_IDENTIFIER_EXPANSION=$'\uE791'
 
+typeset -g POWERLEVEL9K_MISE_PYTHON_FOREGROUND='deepskyblue4'
+typeset -g POWERLEVEL9K_MISE_PYTHON_BACKGROUND='none'
+typeset -g POWERLEVEL9K_MISE_PYTHON_VISUAL_IDENTIFIER_EXPANSION=$'\uE606'
 typeset -g POWERLEVEL9K_AWS_FOREGROUND='yellow'
 typeset -g POWERLEVEL9K_AWS_BACKGROUND='none'
 

--- a/ansible/roles/development/tasks/main.yml
+++ b/ansible/roles/development/tasks/main.yml
@@ -1,10 +1,5 @@
 ---
-- name: Set default asdf version
-  set_fact:
-    development_asdf_version: "v0.18.0"
-  when: ansible_facts['os_family'] == 'Debian'
-
-- name: Install packages for asdf
+- name: Install packages for mise
   apt:
     name:
       - zlib1g-dev
@@ -16,70 +11,24 @@
       - git
       - bash
       - curl
+      - gpg
   become: true
   when: ansible_facts['os_family'] == 'Debian'
 
-- name: Get latest asdf version  # noqa: command-instead-of-module
+- name: Install mise via install script for Linux  # noqa: command-instead-of-module
   shell: |
     set -o pipefail
-    curl -s https://api.github.com/repos/asdf-vm/asdf/releases/latest | grep -oP '"tag_name":\s*"\K[^"]+'
+    curl https://mise.run | sh
   args:
     executable: /bin/bash
-  register: development_asdf_version_result
-  changed_when: false
-  failed_when: false
-  when: ansible_facts['os_family'] == 'Debian'
-
-- name: Set asdf version from API
-  set_fact:
-    development_asdf_version: "{{ development_asdf_version_result.stdout }}"
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - development_asdf_version_result is defined
-    - development_asdf_version_result.stdout is defined
-    - development_asdf_version_result.stdout | length > 0
-
-- name: Check if asdf is already installed
-  stat:
-    path: /usr/local/bin/asdf
-  register: development_asdf_binary
-  when: ansible_facts['os_family'] == 'Debian'
-
-- name: Download asdf pre-compiled binary  # noqa: command-instead-of-module
-  shell: |
-    curl -L -o "/tmp/asdf-{{ development_asdf_version }}-linux-amd64.tar.gz" \
-      "https://github.com/asdf-vm/asdf/releases/download/{{ development_asdf_version }}/asdf-{{ development_asdf_version }}-linux-amd64.tar.gz"
-  args:
-    creates: "/tmp/asdf-{{ development_asdf_version }}-linux-amd64.tar.gz"
-    executable: /bin/bash
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - not development_asdf_binary.stat.exists
-    - not ansible_check_mode
-
-- name: Extract asdf binary
-  unarchive:
-    src: "/tmp/asdf-{{ development_asdf_version }}-linux-amd64.tar.gz"
-    dest: /usr/local/bin
-    remote_src: true
-    creates: /usr/local/bin/asdf
+    creates: /usr/local/bin/mise
   become: true
   when:
     - ansible_facts['os_family'] == 'Debian'
-    - not development_asdf_binary.stat.exists
     - not ansible_check_mode
 
-- name: Cleanup asdf tarball
-  file:
-    path: "/tmp/asdf-{{ development_asdf_version }}-linux-amd64.tar.gz"
-    state: absent
-  when:
-    - ansible_facts['os_family'] == 'Debian'
-    - not development_asdf_binary.stat.exists
-    - not ansible_check_mode
-
-- name: Install asdf for Mac
+- name: Install mise for Mac
   community.general.homebrew:
     name:
-      - asdf
+      - mise
   when: ansible_facts['os_family'] == 'Darwin'


### PR DESCRIPTION
## Summary
- ランタイムバージョン管理ツールを asdf-vm から mise に移行
- zshの補完設定・プロンプト表示(powerlevel10k)を mise 対応に変更
- Ansibleのプロビジョニングタスクを mise インストールに簡素化

## Changes
- `.asdfrc` を削除
- `.zsh/config/completion.zsh`: asdf依存の補完設定を削除し、`mise which` に変更
- `.zsh/config/plugin.zsh`: powerlevel10kのセグメントを `asdf` から `mise_node`/`mise_ruby`/`mise_python` に変更
- `ansible/roles/development/tasks/main.yml`: asdfのバイナリダウンロード・展開処理を `mise.run` スクリプトに置換