### PR TITLE
Complete mise setup and update configurations

### DIFF
--- a/.zsh/config/plugin.zsh
+++ b/.zsh/config/plugin.zsh
@@ -68,6 +68,10 @@ typeset -g POWERLEVEL9K_VCS_UNSTAGED_ICON=$'\uF06A ' # 
 typeset -g POWERLEVEL9K_VCS_STAGED_ICON=$'\uF055 ' # 
 
 # mise custom segments
+if type mise > /dev/null 2>&1; then
+    eval "$(mise activate zsh)"
+fi
+
 function prompt_mise_node() {
     local v
     v=$(mise current node 2>/dev/null)

--- a/ansible/roles/development/README.md
+++ b/ansible/roles/development/README.md
@@ -2,26 +2,22 @@
 
 ## Overview
 
-This role installs asdf version manager, which allows you to manage multiple runtime versions for various programming languages and tools.
+This role installs mise version manager, which allows you to manage multiple runtime versions for various programming languages and tools.
 
 ## Description
 
 ### For Debian/Ubuntu Systems
 
-1. Installs required dependencies for asdf and language builds:
+1. Installs required dependencies for mise and language builds:
    - zlib1g-dev, libbz2-dev, libreadline-dev, libssl-dev
    - libsqlite3-dev, libffi-dev
-   - git, bash, curl
+   - git, bash, curl, gpg
 
-2. Fetches the latest asdf version from GitHub releases API (fallback to v0.18.0)
-
-3. Downloads and extracts the pre-compiled asdf binary to `/usr/local/bin`
-
-4. Cleans up temporary installation files
+2. Downloads and installs mise to `/usr/local/bin/mise` using the official install script.
 
 ### For macOS Systems
 
-Installs asdf via Homebrew
+Installs mise via Homebrew
 
 ## Requirements
 
@@ -34,19 +30,19 @@ Installs asdf via Homebrew
 
 ## Platform Support
 
-- Linux (Debian/Ubuntu) - Pre-compiled binary installation
+- Linux (Debian/Ubuntu) - Install script (installed to `/usr/local/bin/mise`)
 - macOS (Darwin) - Homebrew installation
 
 ## Post-Installation
 
-After installation, configure your shell to initialize asdf. Add to your shell configuration:
+After installation, configure your shell to initialize mise. Add to your shell configuration:
 
-```bash
-# For Debian/Ubuntu
-. /usr/local/bin/asdf
+```zsh
+# For zsh
+eval "$(mise activate zsh)"
 
-# For macOS (if installed via Homebrew)
-. $(brew --prefix asdf)/libexec/asdf.sh
+# For bash
+eval "$(mise activate bash)"
 ```
 
 ## Example Usage
@@ -57,13 +53,11 @@ After installation, configure your shell to initialize asdf. Add to your shell c
     - development
 ```
 
-## What is asdf?
+## What is mise?
 
-asdf is a CLI tool that manages multiple runtime versions for various languages like:
-- Node.js
-- Python
-- Ruby
-- Go
-- And many more via plugins
+mise (formerly rtx) is a polyglot runtime manager. Its features include:
+- Fast: written in Rust, significantly faster than asdf.
+- Compatible: supports asdf plugins and `.tool-versions` files.
+- Simple: single binary, no shims required (optionally).
 
-For more information, visit: https://asdf-vm.com/
+For more information, visit: https://mise.jdx.dev/

--- a/ansible/roles/development/tasks/main.yml
+++ b/ansible/roles/development/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Install mise via install script for Linux  # noqa: command-instead-of-module
   shell: |
     set -o pipefail
-    curl https://mise.run | sh
+    curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
   args:
     executable: /bin/bash
     creates: /usr/local/bin/mise


### PR DESCRIPTION
This PR completes the migration from asdf to mise by:
1. Adding automatic mise activation to the zsh configuration.
2. Fixing the Ansible task to install mise to the intended system path (/usr/local/bin).
3. Updating the development role README to reflect the mise migration.