### PR TITLE
migrate exa to eza in ls aliases

### DIFF
--- a/.zsh/config/alias.zsh
+++ b/.zsh/config/alias.zsh
@@ -17,11 +17,11 @@ alias tm='terminal'
 alias vdir='ls --color=auto --format=long'
 
 # ls
-if type "exa" > /dev/null 2>&1; then
-    alias ls='exa'
-    alias l='exa -F'
-    alias la='exa -a'
-    alias ll='exa -l'
+if type "eza" > /dev/null 2>&1; then
+    alias ls='eza'
+    alias l='eza -F'
+    alias la='eza -a'
+    alias ll='eza -l'
 else
     alias ls='ls -h --color=always'
     alias l='ls -CF'


### PR DESCRIPTION
close #58

## Summary
- `exa` は2023年にアーカイブされ開発停止済みのため、コミュニティフォークの `eza` に移行
- `.zsh/config/alias.zsh` 内の `exa` 参照5箇所を `eza` に置換
- `eza` は `exa` とCLI互換のため、オプション変更は不要