### PR TITLE
remove duplicate LESS definition from .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -8,9 +8,6 @@
 # If not running interactively, don't do anything
 [[ "$-" != *i* ]] && return
 
-# less
-export LESS='-R'
-
 # Load .linuxbrewrc
 if [[ -e ~/.linuxbrewrc ]]; then
     source ~/.linuxbrewrc


### PR DESCRIPTION
## Summary
- `.bashrc` と `.zshrc` で重複定義されていた `LESS` 環境変数を `.bashrc` から削除
- `.zshrc` が `source ~/.bashrc` しているため、`.bashrc` 側の定義は不要

## 設計判断
当初は環境変数をmise `conf.d/env.toml` に集約する方針だったが、以下の理由で方針変更:
- `FZF_DEFAULT_OPTS` が `search.zsh` から離れる等、設定の凝集性が下がる
- miseはツールバージョン管理に専念させ、シェル設定（env/alias）は `.zshrc` 系に留める

## Test plan
- [ ] `echo $LESS` で `-R` が設定されていることを確認

Closes #60