### PR TITLE
add minimumReleaseAge to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
   ],
   "enabledManagers": [
     "mise"
-  ]
+  ],
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
## Summary

Renovate の `minimumReleaseAge` を3日に設定し、リリース直後の悪意あるバージョンを自動でPR作成しないようにする。

## Test plan

- [ ] Renovate Dashboard で設定が反映されていること