### PR TITLE
remove duplicate alias g for grep

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           eval "$(mise activate bash)"
           mise install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: run test
         run: |
           eval "$(mise activate bash)"

--- a/.zsh/config/alias.zsh
+++ b/.zsh/config/alias.zsh
@@ -45,7 +45,6 @@ alias zshconfig='nvim $(readlink -f ~/.zshrc)'
 alias vimconfig='nvim $(readlink -f ~/.config/nvim/init.lua)'
 
 # grep
-alias g='grep --color=always'
 alias grep='grep --color=always'
 alias jgrep='grep --include="*.java"'
 alias jsgrep='grep --include="*.js"'


### PR DESCRIPTION
Close #64

## Summary
- `.zsh/config/alias.zsh` の48行目 `alias g='grep --color=always'` を削除
- 58行目の `alias g='git'` に上書きされており、grep 用の定義は無効だった
- `grep` コマンド自体は49行目の `alias grep='grep --color=always'` で色付き済み

## Additional fix
- `.github/workflows/install.yml` の mise install ステップに `GITHUB_TOKEN` を渡すように修正
- macOS CI で GitHub API レートリミット (403) により mise install が失敗していた問題を解消