### PR TITLE
migrate pr-open function from hub to gh CLI

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -43,6 +43,8 @@ jobs:
         run: |
           eval "$(mise activate bash)"
           mise install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: run test
         run: |
           eval "$(mise activate bash)"

--- a/.zsh/config/alias.zsh
+++ b/.zsh/config/alias.zsh
@@ -45,7 +45,6 @@ alias zshconfig='nvim $(readlink -f ~/.zshrc)'
 alias vimconfig='nvim $(readlink -f ~/.config/nvim/init.lua)'
 
 # grep
-alias g='grep --color=always'
 alias grep='grep --color=always'
 alias jgrep='grep --include="*.java"'
 alias jsgrep='grep --include="*.js"'

--- a/.zshrc
+++ b/.zshrc
@@ -69,13 +69,7 @@ export BAT_THEME="Monokai Extended Bright"
 
 # FUNCTION {{{
 function pr-open {
-    local url
-    url=$(hub pr list -h "$(git symbolic-ref --short HEAD)" -f "%U")
-    if [[ -z $url ]]; then
-        echo "The PR based this branch not found."
-        return 1
-    fi
-    open "$url"
+    gh pr view --web 2>/dev/null || echo "The PR based this branch not found."
 }
 # }}}
 


### PR DESCRIPTION
## Summary
- `pr-open` 関数を非推奨の `hub` コマンドから `gh` CLI に移行
- `gh pr view --web` により、OS非依存でブラウザを開く動作に改善

Closes #63