### PR TITLE
promote direnv hook and GPG_TTY to shared dotfiles

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -81,6 +81,15 @@ fi
 # }}}
 
 # OTHER {{{
+# GPG
+GPG_TTY=$(tty)
+export GPG_TTY
+
+# direnv
+if type direnv > /dev/null 2>&1; then
+    eval "$(direnv hook zsh)"
+fi
+
 # neovim
 export XDG_CONFIG_HOME=~/.config
 export BUNDLER_EDITOR=vi


### PR DESCRIPTION
## Summary
- 両マシンの `.zshrc_local` に重複定義されていた `direnv hook` と `GPG_TTY` を `.zshrc` に昇格
- `direnv hook` は `type` チェック付きで未インストール環境でも安全に動作

Closes #67