### PR TITLE
CIの共通化・stylua導入・依存更新の自動化拡充

### DIFF
--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -33,7 +33,6 @@ map("n", "<C-p>", "<cmd>cprevious<CR>")
 map("s", "<CR>", "<BS>i")
 map("t", "<Esc>", "<C-\\><C-n>", { silent = true })
 
-
 -- <leader>yd to yank diagnostics at the current line
 local function yank_line_diagnostics()
   local diags = vim.diagnostic.get(0, { lnum = vim.fn.line(".") - 1 })
@@ -44,12 +43,10 @@ local function yank_line_diagnostics()
 
   local lines = {}
   for _, d in ipairs(diags) do
-    table.insert(lines, string.format(
-      "[%s] %s (%s)",
-      vim.diagnostic.severity[d.severity],
-      d.message,
-      d.source or "LSP"
-    ))
+    table.insert(
+      lines,
+      string.format("[%s] %s (%s)", vim.diagnostic.severity[d.severity], d.message, d.source or "LSP")
+    )
   end
 
   vim.fn.setreg("+", table.concat(lines, "\n"))
@@ -57,5 +54,5 @@ local function yank_line_diagnostics()
 end
 
 vim.keymap.set("n", "<leader>yd", yank_line_diagnostics, {
-  desc = "Yank diagnostics at cursor"
+  desc = "Yank diagnostics at cursor",
 })

--- a/.config/nvim/lua/plugins/coding.lua
+++ b/.config/nvim/lua/plugins/coding.lua
@@ -28,8 +28,8 @@ return {
           option = {
             get_cwd = function()
               return vim.fn.getcwd()
-            end
-          }
+            end,
+          },
         })
       end
 
@@ -57,12 +57,12 @@ return {
             elseif luasnip.expand_or_jumpable() then
               luasnip.expand_or_jump()
             else
-              local col = vim.fn.col('.') - 1
-              local line = vim.fn.getline('.')
+              local col = vim.fn.col(".") - 1
+              local line = vim.fn.getline(".")
               local char = line:sub(col, col)
-              if col == 0 or char:match('%s') then
-                local spaces = string.rep(' ', vim.bo.shiftwidth)
-                vim.api.nvim_put({ spaces }, 'c', false, true)
+              if col == 0 or char:match("%s") then
+                local spaces = string.rep(" ", vim.bo.shiftwidth)
+                vim.api.nvim_put({ spaces }, "c", false, true)
               else
                 fallback()
               end

--- a/.github/actions/setup-ansible/action.yml
+++ b/.github/actions/setup-ansible/action.yml
@@ -1,0 +1,29 @@
+---
+name: 'Setup Ansible'
+description: 'Set up Python and install Ansible dependencies from requirements.txt'
+inputs:
+  python-version:
+    description: 'Python version to use'
+    default: '3.12'
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      id: python
+      with:
+        python-version: ${{ inputs.python-version }}
+    # The apt module fails with a non-system python, so on macOS we point
+    # ansible at the setup-python interpreter explicitly.
+    - name: set python path
+      shell: bash
+      run: echo -e "[defaults]\ninterpreter_python=${{ steps.python.outputs.python-path }}" > ansible/ansible.cfg
+      if: runner.os == 'macOS'
+    - name: install python dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade setuptools
+        pip install -r ansible/requirements.txt
+    - name: install ansible collections
+      shell: bash
+      run: ansible-galaxy collection install -r ansible/requirements.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: monthly

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -23,18 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        id: python
-        with:
-          python-version: '3.12'
-      - name: set python path
-        run: echo -e "[defaults]\ninterpreter_python=${{ steps.python.outputs.python-path }}" > ansible/ansible.cfg
-        if: matrix.os == 'macOS-latest'
-      - name: install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools
-          pip install -r ansible/requirements.txt
+      - uses: ./.github/actions/setup-ansible
       - name: dryrun dotfiles
         run: make check-dotfiles
       - name: dryrun dependencies

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -23,18 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        id: python
-        with:
-          python-version: '3.12'
-      - name: set python path
-        run: echo -e "[defaults]\ninterpreter_python=${{ steps.python.outputs.python-path }}" > ansible/ansible.cfg
-        if: matrix.os == 'macOS-latest'
-      - name: install python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools
-          pip install -r ansible/requirements.txt
+      - uses: ./.github/actions/setup-ansible
       - name: install dotfiles
         run: make dotfiles
       - name: install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,19 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
-        id: python
-        with:
-          python-version: '3.12'
-      - name: set python path
-        run: echo -e "[defaults]\ninterpreter_python=${{ steps.python.outputs.python-path }}" > ansible/ansible.cfg
-      - name: install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools
-          pip install -r ansible/requirements.txt
-      - name: install ansible collections
-        run: ansible-galaxy collection install -r ansible/requirements.yml
+      - uses: ./.github/actions/setup-ansible
       - name: lint
         run: make lint
       # Run shellcheck directly because shellcheck actions skip files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,9 @@ jobs:
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           version: v0.8.0
+      - name: stylua
+        uses: JohnnyMorganz/stylua-action@76fd70c03e6340ceaf673366712db9b20560b402 # v5.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: v2.3.1
+          args: --check .config/nvim

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+    version: "12.1.0"

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,10 @@
     "config:recommended"
   ],
   "enabledManagers": [
-    "mise"
+    "mise",
+    "pip_requirements",
+    "ansible-galaxy",
+    "github-actions"
   ],
   "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
dotfiles改善調査（#74に続く後続対応）の残項目をまとめて対応する。

## 変更内容

### 1. CIセットアップの共通化（調査項目9）
- `dryrun` / `install` / `lint` の3ワークフローで重複していた checkout 後の「setup-python → ansible.cfg生成 → pip install」を `.github/actions/setup-ansible` composite action に切り出し
- macOS で interpreter_python を指定する条件分岐は `runner.os == 'macOS'` に統一

### 2. styluaによるNeovim設定のCIチェック（調査項目8）
- `lint` ワークフローに stylua の `--check` ステップを追加（shellcheck と同様にCIで直接実行）
- 既存の `.config/nvim` 配下のLua設定を `.stylua.toml` の規約に合わせて整形

### 3. 依存更新の自動化拡充（調査項目7）
- `renovate.json` の `enabledManagers` に `pip_requirements` / `ansible-galaxy` / `github-actions` を追加
  - `ansible/requirements.txt`・`requirements.yml` も自動更新対象に
  - GitHub Actions の更新を Dependabot から Renovate に統合し `.github/dependabot.yml` を削除
- Renovate が追従できるよう `community.general` のバージョンを `12.1.0` に固定

## 確認
- ローカルで `stylua --check .config/nvim` がパスすることを確認済み