### PR TITLE
add tmux window title with repo/dir name and Claude state icon

### DIFF
--- a/.scripts/tmux-title
+++ b/.scripts/tmux-title
@@ -1,0 +1,68 @@
+#!/usr/bin/env zsh
+#
+# tmux の window 名を「<Claude状態アイコン> <リポジトリ名 or ディレクトリ名>」に設定する。
+#
+# 対話シェル(chpwd)と Claude Code の hook の両方から、同じこのスクリプトを呼ぶ。
+#   - base名(リポジトリ名/ディレクトリ名) は window option @win_base にキャッシュし、
+#     ディレクトリが変わりうるタイミング(chpwd/UserPromptSubmit 等)でだけ git を叩く。
+#     PostToolUse 等の高頻度 hook はアイコン差し替えだけで済む。
+#   - アイコン(状態) は window option @claude_icon に保持する。
+#     Claude hook が無い環境(例: Linux)では常に空 → アイコン無しで base名だけになる。
+#
+# usage: tmux-title [state] [refresh]
+#   state   : idle | working | waiting | done | clear | keep(既定, アイコンを変えない)
+#   refresh : "refresh" を渡すと base名を再計算する
+#
+# アイコンは Nerd Font (Material Design Icons):
+#   idle=clock-outline / working=lightning-bolt / waiting=bell-ring / done=check
+
+# このスクリプトは非対話 zsh(.zshenv のみ)で起動されるため、呼び出し元の PATH が
+# 貧弱なことがある。PATH に頼らず tmux/git を実在パスから解決する。
+# tmux が見つからなければ何もせず終了する(エラーを出さない)。
+_bin() {
+  local c
+  for c in "$@"; do
+    if [[ "$c" == /* ]]; then
+      [[ -x "$c" ]] && { print -r -- "$c"; return 0 }
+    else
+      c=$(command -v "$c" 2>/dev/null) && { print -r -- "$c"; return 0 }
+    fi
+  done
+  return 1
+}
+TMUXBIN=$(_bin tmux /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux) || exit 0
+GITBIN=$(_bin git /opt/homebrew/bin/git /usr/bin/git) || GITBIN=git
+
+[[ -z "$TMUX" ]] && exit 0
+pane="${TMUX_PANE:-}"
+[[ -z "$pane" ]] && exit 0
+
+state="${1:-keep}"
+refresh="${2:-}"
+
+# 1. 状態アイコンを更新 (keep のときは触らない)
+case "$state" in
+  idle)    "$TMUXBIN" set-option -w -t "$pane" @claude_icon $'\U000F0150' ;;
+  working) "$TMUXBIN" set-option -w -t "$pane" @claude_icon $'\U000F140B' ;;
+  waiting) "$TMUXBIN" set-option -w -t "$pane" @claude_icon $'\U000F009C' ;;
+  done)    "$TMUXBIN" set-option -w -t "$pane" @claude_icon $'\U000F012C' ;;
+  clear)   "$TMUXBIN" set-option -w -t "$pane" @claude_icon '' ;;
+  keep)    ;;
+esac
+
+# 2. base名: キャッシュを使う。refresh 指定 or キャッシュ空なら再計算。
+base=$("$TMUXBIN" show-option -wqv -t "$pane" @win_base)
+if [[ "$refresh" == refresh || -z "$base" ]]; then
+  path=$("$TMUXBIN" display-message -p -t "$pane" '#{pane_current_path}')
+  if root=$("$GITBIN" -C "$path" rev-parse --show-toplevel 2>/dev/null); then
+    base=${root:t}   # リポジトリ名
+  else
+    base=${path:t}   # ディレクトリ名
+  fi
+  "$TMUXBIN" set-option -w -t "$pane" @win_base "$base"
+fi
+
+# 3. 描画
+icon=$("$TMUXBIN" show-option -wqv -t "$pane" @claude_icon)
+[[ -n "$icon" ]] && icon="$icon "
+"$TMUXBIN" rename-window -t "$pane" "${icon}${base}"

--- a/.zsh/config/search.zsh
+++ b/.zsh/config/search.zsh
@@ -23,9 +23,7 @@ function fzf-ghq-look () {
     selected_dir=$(ghq list | fzf --preview=)
     if [ -n "$selected_dir" ]; then
         BUFFER="cd $(ghq list --full-path | grep --color=never -E "/$selected_dir$")"
-        if [[ "$TERM_PROGRAM" == "tmux" ]]; then
-            tmux rename-window "$(basename "$selected_dir")"
-        fi
+        # window 名は cd 後の chpwd フック(tmux.zsh)が設定するため、ここでは行わない
         zle accept-line
     fi
 }

--- a/.zsh/config/tmux.zsh
+++ b/.zsh/config/tmux.zsh
@@ -1,0 +1,9 @@
+# tmux: window 名を「リポジトリ名 / ディレクトリ名」に自動設定する。
+# 実処理は ~/.scripts/tmux-title に集約 (Claude Code の hook からも同じスクリプトを使う)。
+# tmux 外 / ヘルパー未配置(make dotfiles 前や未対応環境)では何もしない。
+if [[ -n "$TMUX" && -x ~/.scripts/tmux-title ]]; then
+  autoload -Uz add-zsh-hook
+  _tmux_title_chpwd() { ~/.scripts/tmux-title keep refresh; }
+  add-zsh-hook chpwd _tmux_title_chpwd
+  # 起動時は set しない (cd したときだけ更新)
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -120,6 +120,9 @@ source ~/.zsh/config/completion.zsh
 # search
 source ~/.zsh/config/search.zsh
 
+# tmux
+source ~/.zsh/config/tmux.zsh
+
 # local setting
 if [[ -e ~/.zshrc_local ]]; then
     source ~/.zshrc_local


### PR DESCRIPTION
## 概要
tmux の window 名を「**<Claude状態アイコン> <リポジトリ名 or ディレクトリ名>**」に自動設定する。

- git リポジトリ内 → リポジトリ名（`git rev-parse --show-toplevel` の basename）
- それ以外 → ディレクトリ名

## 変更
- **`.scripts/tmux-title`**: 本体。chpwd フックと Claude Code の hook の両方から共用。base名を window option `@win_base` にキャッシュし、状態アイコンを `@claude_icon` に保持。tmux/git は PATH に頼らず実在パスから解決（非対話 zsh で PATH が貧弱でも動作）。tmux 外では no-op。
- **`.zsh/config/tmux.zsh`**: chpwd フック登録（起動時は rename しない）。
- **`.zshrc`**: 上記を source。
- **`.zsh/config/search.zsh`**: fzf-ghq-look の手動 rename を削除（chpwd に一本化）。

## Claude 状態アイコン
Nerd Font (Material Design Icons) を使用し、マシンローカルの Claude Code hook が駆動:
idle=clock-outline / working=lightning-bolt / waiting=bell-ring / done=check。
Claude hook が無い環境（例: Linux）ではアイコン空 → **repo名/dir名のみに自然縮退**。

## 動作確認
- 起動時（rename しない）/ cd 時 / Ctrl+G(ghq) 移動 いずれも想定通り
- `shellcheck .zshrc .zsh/config/*.zsh` PASS、`zsh -n` 全 PASS